### PR TITLE
cref 增加连续引用假设定义环境

### DIFF
--- a/cumcmthesis.cls
+++ b/cumcmthesis.cls
@@ -50,6 +50,7 @@ Just choose `xelatex', no `pdflatex' or `latex' and so on.}
 \RequirePackage{xcolor}
 % 插入图片
 \RequirePackage{graphicx}
+\RequirePackage{float}
 % 表格
 \RequirePackage{array}
 %% 长表格
@@ -67,10 +68,17 @@ Just choose `xelatex', no `pdflatex' or `latex' and so on.}
 % 设置代码环境
 \RequirePackage{listings}
 \RequirePackage{xcolor}
+% 插入链接
+\RequirePackage{url}
+% 绘图的包
+\RequirePackage{tikz}
 
+
+% 字图与子标题
+\RequirePackage{subcaption}
 \RequirePackage[titles]{tocloft}
 %\renewcommand{\cftdot}{$\cdot$}
-%\renewcommand{\cftsecdotsep}{1.5} 
+%\renewcommand{\cftsecdotsep}{1.5}
 \renewcommand{\cftsecdotsep}{4.5}
 \setlength{\cftbeforesecskip}{7pt}
 \setlength{\cftbeforesubsecskip}{3pt}
@@ -257,22 +265,57 @@ Just choose `xelatex', no `pdflatex' or `latex' and so on.}
 \crefrangeformat{table}{表(#3#1#4)\;\~{}\;(#5#2#6)}
 \crefmultiformat{table}{表~(#2#1#3)}{和~(#2#1#3)}{，(#2#1#3)}{和~(#2#1#3)}
 
-\crefformat{equation}{#2~(#1#3)}
-\crefrangeformat{equation}{~(#3#1#4)\;\~{}\;(#5#2#6)}
-\crefmultiformat{equation}{~(#2#1#3)}{ 和~(#2#1#3)}{，(#2#1#3)}{ 和~(#2#1#3)}
+\crefformat{equation}{#2公式(#1#3)}
+\crefrangeformat{equation}{公式(#3#1#4)\;\~{}\;(#5#2#6)}
+\crefmultiformat{equation}{公式(#2#1#3)}{ 和~(#2#1#3)}{，(#2#1#3)}{ 和~(#2#1#3)}
 
 \crefformat{definition}{#2\mcm@cap@definition~#1#3}
+\crefrangeformat{definition}{\mcm@cap@definition(#3#1#4)\;\~{}\;(#5#2#6)}
+\crefmultiformat{definition}{\mcm@cap@definition(#2#1#3)}{ 和~(#2#1#3)}{，(#2#1#3)}{ 和~(#2#1#3)}
+
 \crefformat{theorem}{#2\mcm@cap@theorem~#1#3}
+\crefrangeformat{theorem}{\mcm@cap@theorem(#3#1#4)\;\~{}\;(#5#2#6)}
+\crefmultiformat{theorem}{\mcm@cap@theorem(#2#1#3)}{ 和~(#2#1#3)}{，(#2#1#3)}{ 和~(#2#1#3)}
+
 \crefformat{lemma}{#2\mcm@cap@lemma~#1#3}
+\crefrangeformat{lemma}{\mcm@cap@lemma(#3#1#4)\;\~{}\;(#5#2#6)}
+\crefmultiformat{lemma}{\mcm@cap@lemma(#2#1#3)}{ 和~(#2#1#3)}{，(#2#1#3)}{ 和~(#2#1#3)}
+
 \crefformat{corollary}{#2\mcm@cap@corollary~#1#3}
+\crefrangeformat{corollary}{\mcm@cap@corollary(#3#1#4)\;\~{}\;(#5#2#6)}
+\crefmultiformat{corollary}{\mcm@cap@corollary(#2#1#3)}{ 和~(#2#1#3)}{，(#2#1#3)}{ 和~(#2#1#3)}
+
 \crefformat{assumption}{#2\mcm@cap@assumption~#1#3}
+\crefrangeformat{assumption}{\mcm@cap@assumption(#3#1#4)\;\~{}\;(#5#2#6)}
+\crefmultiformat{assumption}{\mcm@cap@assumption(#2#1#3)}{ 和~(#2#1#3)}{，(#2#1#3)}{ 和~(#2#1#3)}
+
 \crefformat{conjecture}{#2\mcm@cap@conjecture~#1#3}
+\crefrangeformat{conjecture}{\mcm@cap@conjecture(#3#1#4)\;\~{}\;(#5#2#6)}
+\crefmultiformat{conjecture}{\mcm@cap@conjecture(#2#1#3)}{ 和~(#2#1#3)}{，(#2#1#3)}{ 和~(#2#1#3)}
+
 \crefformat{axiom}{#2\mcm@cap@axiom~#1#3}
+\crefrangeformat{axiom}{\mcm@cap@axiom(#3#1#4)\;\~{}\;(#5#2#6)}
+\crefmultiformat{axiom}{\mcm@cap@axiom(#2#1#3)}{ 和~(#2#1#3)}{，(#2#1#3)}{ 和~(#2#1#3)}
+
 \crefformat{principle}{#2\mcm@cap@principle~#1#3}
+\crefrangeformat{principle}{\mcm@cap@principle(#3#1#4)\;\~{}\;(#5#2#6)}
+\crefmultiformat{principle}{\mcm@cap@principle(#2#1#3)}{ 和~(#2#1#3)}{，(#2#1#3)}{ 和~(#2#1#3)}
+
 \crefformat{problem}{#2\mcm@cap@problem~#1#3}
+\crefrangeformat{problem}{\mcm@cap@problem(#3#1#4)\;\~{}\;(#5#2#6)}
+\crefmultiformat{problem}{\mcm@cap@problem(#2#1#3)}{ 和~(#2#1#3)}{，(#2#1#3)}{ 和~(#2#1#3)}
+
 \crefformat{example}{#2\mcm@cap@example~#1#3}
+\crefrangeformat{example}{\mcm@cap@example(#3#1#4)\;\~{}\;(#5#2#6)}
+\crefmultiformat{example}{\mcm@cap@example(#2#1#3)}{ 和~(#2#1#3)}{，(#2#1#3)}{ 和~(#2#1#3)}
+
 \crefformat{proof}{#2\mcm@cap@proof~#1#3}
+\crefrangeformat{proof}{\mcm@cap@proof(#3#1#4)\;\~{}\;(#5#2#6)}
+\crefmultiformat{proof}{\mcm@cap@proof(#2#1#3)}{ 和~(#2#1#3)}{，(#2#1#3)}{ 和~(#2#1#3)}
+
 \crefformat{solution}{#2\mcm@cap@solution~#1#3}
+\crefrangeformat{solution}{\mcm@cap@solution(#3#1#4)\;\~{}\;(#5#2#6)}
+\crefmultiformat{solution}{\mcm@cap@solution(#2#1#3)}{ 和~(#2#1#3)}{，(#2#1#3)}{ 和~(#2#1#3)}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 %% Document Markup
@@ -467,13 +510,13 @@ Just choose `xelatex', no `pdflatex' or `latex' and so on.}
 	\vskip1ex
 	{\noindent\zihao{-4}\heiti\mcm@cap@keywordsname：}~{\mcm@tokens@keywords}
 	}
-% 定义附录	
+% 定义附录
 
 % \renewcommand{\setthesection}{\appendixname\Alph{section}}
 % \renewcommand\appendix{\par
 	% \setcounter{section}{0}%
 	 % \setcounter{subsection}{0}%
-	% \gdef\thesection{\appendixname\@Alph\c@section}}		
+	% \gdef\thesection{\appendixname\@Alph\c@section}}
 % 重定义参考文献环境
 \renewenvironment{thebibliography}[1]
      {\section*{\refname}%
@@ -493,7 +536,7 @@ Just choose `xelatex', no `pdflatex' or `latex' and so on.}
       \sfcode`\.\@m}
      {\def\@noitemerr
        {\@latex@warning{Empty `thebibliography' environment}}%
-      \endlist}	
+      \endlist}
 
 \newcommand*\tihao[1]{%
 	\renewcommand{\mcm@tokens@tihao}{#1}}


### PR DESCRIPTION
`float` - 插图的时候可以使用`[H]`控制,让浮动体就在这里

`url` - 插入链接(之前例子里好像有, 没有在模板中导入)

`subcaption` - 子图的子标题(之前例子里好像有, 没有在模板中导入)

去掉了一些多于空格(编辑器自动去掉的)